### PR TITLE
add wp_json endpoints

### DIFF
--- a/modules/wp-rest-api.php
+++ b/modules/wp-rest-api.php
@@ -1,0 +1,54 @@
+<?php
+class WP_JSON_SIRP extends WP_JSON_Posts {
+
+	public function register_routes( $routes ) {
+		$ranking_routes = array(
+			'/posts/(?P<id>\d+)/sirp_related' => array(
+				array( array( $this, 'get_related' ), WP_JSON_Server::READABLE ),
+			),
+			'/sirp_related/(?P<id>\d+)' => array(
+				array( array( $this, 'get_related' ), WP_JSON_Server::READABLE ),
+			),
+		);
+		return array_merge( $routes, $ranking_routes );
+	}
+
+	public function get_related( $id = '', $filter = array(), $context = 'view'  ) {
+		$option     = get_option('sirp_options');
+		$num        = ! empty( $filter['num'] ) ? (int) $filter['num'] : (int) $option['display_num'];
+		$ids        = sirp_get_related_posts_id_api( $num, $id );
+		$posts_list = array();
+		foreach ( $ids as $id ) {
+			$posts_list[] = get_post( $id );
+		}
+		$response = new WP_JSON_Response();
+
+		if ( ! $posts_list ) {
+			$response->set_data( array() );
+			return $response;
+		}
+
+		$struct = array();
+
+		$response->header( 'Last-Modified', mysql2date( 'D, d M Y H:i:s', get_lastpostmodified( 'GMT' ), 0 ).' GMT' );
+
+		foreach ( $posts_list as $post ) {
+			$post = get_object_vars( $post );
+
+			if ( ! $this->check_read_permission( $post ) ) {
+				continue;
+			}
+
+			$response->link_header( 'item', json_url( '/posts/' . $post['ID'] ), array( 'title' => $post['post_title'] ) );
+			$post_data = $this->prepare_post( $post, $context );
+			if ( is_wp_error( $post_data ) ) {
+				continue;
+			}
+
+			$struct[] = $post_data;
+		}
+		$response->set_data( $struct );
+		return $response;
+	}
+
+}

--- a/simple-related-posts.php
+++ b/simple-related-posts.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /*
 Plugin Name: WP Simple Related Posts
 Plugin URI: http://www.kakunin-pl.us/
@@ -29,7 +29,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 if ( ! defined( 'SIRP_DOMAIN' ) )
 	define( 'SIRP_DOMAIN', 'wp-simple-related-posts' );
-	
+
 if ( ! defined( 'SIRP_PLUGIN_URL' ) )
 	define( 'SIRP_PLUGIN_URL', plugins_url() . '/' . dirname( plugin_basename( __FILE__ ) ));
 
@@ -90,7 +90,7 @@ EOM;
 
 class Simple_Related_Posts {
 	private $related = '';
-	
+
 	public function __construct() {
 		$this->requirements();
 		$option = get_option('sirp_options');
@@ -98,7 +98,7 @@ class Simple_Related_Posts {
 			$this->related = new $option['target'];
 		}
 	}
-		
+
 	private function requirements() {
 		require_once(SIRP_PLUGIN_DIR . '/modules/base.php');
 
@@ -117,18 +117,29 @@ class Simple_Related_Posts {
 		}
 		do_action( 'sirp_addon_requirement' );
 	}
-	
+
 	public function get_data_original($num = '') {
 		return $this->related->get_data_original($num);
-	} 
-	
+	}
+
 	public function get_data($num = '') {
 		return $this->related->get_data($num);
 	}
-	
+
 	public function get_data_api( $num = '', $post_id = null ) {
 		return $this->related->get_data_api($num, $post_id);
 	}
 }
 
 $simple_related_posts = new Simple_Related_Posts();
+
+if ( is_plugin_active( 'json-rest-api/plugin.php' ) && ( '3.9.2' <= get_bloginfo( 'version' ) && '4.2' > get_bloginfo( 'version' ) ) ) {
+	require_once( SIRP_PLUGIN_DIR . '/modules/wp-rest-api.php' );
+
+	function sirp_json_api_related_filters( $server ) {
+		// Related
+		$wp_json_related = new WP_JSON_SIRP( $server );
+		add_filter( 'json_endpoints', array( $wp_json_related, 'register_routes' ), 1 );
+	}
+	add_action( 'wp_json_server_before_serve', 'sirp_json_api_related_filters', 10, 1 );
+}


### PR DESCRIPTION
WP REST API の Endpoints 追加。
/wp-json/posts/%post_id%/sirp_related/
/wp-json/sirp_related/%post_id%/
で表示。
?filter[num]=5
で表示件数をフィルターできます。
